### PR TITLE
feat: app is generic re: project and destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Very simple app to do flexible redirections from perts.me to neptune.perts.net/participate/portal.
 
+* Allows https redirects
+* Applies path and query string to the new domain
+
 ## Setup
 
 1. Install `gcloud` and the python tools like all our other app engine projects. See [Tools for Web Development][1] for environment setup steps.
@@ -10,7 +13,17 @@ Very simple app to do flexible redirections from perts.me to neptune.perts.net/p
 
 ## Behavior
 
-Visiting this app should redirect you to neptune.perts.net/participate/portal. Any path or query string should be appended. For example:
+### HTTPS redirects
+
+Entering a URL in your browser with the https protocol requires a key exchange with _that domain_, before redirection. So the initially targeted domain needs to have a valid TLS certificate. This is non-trivial with some hosting providers, like GoDaddy.
+
+Deploying to App Engine, which automatically manages free certificates, makes this simpler.
+
+Note: the location of the 301 response will always use `https://`.
+
+### Applying path and query string to redirect
+
+We use this app at perts.me to redirect to neptune.perts.net/participate/portal. Any path or query string should be appended. For example:
 
 |       URL        |                 301 redirect                 |
 |------------------|----------------------------------------------|
@@ -18,17 +31,48 @@ Visiting this app should redirect you to neptune.perts.net/participate/portal. A
 | perts.me/XYY     | neptune.perts.net/participate/portal/XYY     |
 | perts.me/XYY?foo | neptune.perts.net/participate/portal/XYY?foo |
 
-## Deployment
+## Development
 
-To deploy to production:
+Build an app.yaml file with a redirection domain and/or path.
 
 ```
-gcloud app deploy app.yaml --project=perts-me --version=production --no-promote
+./build_app_yaml.sh neptune.perts.net/participate/portal
+```
+
+Then start the app.
+
+```
+npm start
+```
+
+It should respond with a 301:
+
+```
+$> curl -I http://localhost:8001/foo
+HTTP/1.1 301 Moved Permanently
+content-length: 0
+location: https://neptune.perts.net/participate/portal/foo
+cache-control: no-cache
+content-type: text/html; charset=utf-8
+Server: Development/2.0
+Date: Mon, 16 May 2022 20:51:41 GMT
+```
+
+## Deployment
+
+To deploy, run the deploy script and specify the project ID and where to redirect. Assumes the App Engine version is "production".
+
+```
+npm run deploy perts-me neptune.perts.net/participate/portal
 ```
 
 To deploy to another version for testing:
 
+1. Make sure to generate the correct app.yaml file with the intended redirect.
+2. Use a custom gcloud command. Don't forget `--no-promote`!
+
 ```
+./build_app_yaml.sh custom-domain.org
 gcloud app deploy app.yaml --project=perts-me --version=acceptance --no-promote
 ```
 

--- a/app.template.yaml
+++ b/app.template.yaml
@@ -1,3 +1,5 @@
+# ^^^The deploy script should insert environment variables above this line^^^
+
 runtime: python27
 api_version: 1
 threadsafe: true

--- a/build_app_yaml.sh
+++ b/build_app_yaml.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ -z $1 ]; then
+  echo "Provide a redirection domain/path, like './build_app_yaml.sh neptune.perts.net/participate/portal'."
+  exit 0
+fi
+
+echo "env_variables:\n  REDIRECT_TO: '$1'\n\n$(cat app.template.yaml)" > app.yaml

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if [ -z $1 ] || [ -z $2 ]; then
+  echo "Provide a project ID and redirection domain/path, like 'npm run deploy perts-me neptune.perts.net/participate/portal'."
+  exit 0
+fi
+
+read -p "Deploy redirector to project '$1' and have it redirect to 'https://$2'? [y/N]: " CONFIRM_DEPLOY
+
+if [ "$CONFIRM_DEPLOY" = 'y' ]; then
+  ./build_app_yaml.sh $2
+  gcloud app deploy app.yaml --project=$1 --version=production --no-promote
+else
+  exit 0
+fi

--- a/main.py
+++ b/main.py
@@ -1,11 +1,21 @@
 from google.appengine.ext import webapp
+import os
 
 
 class AllHandler(webapp.RequestHandler):
     def get(self):
+        redirect_to = os.environ.get('REDIRECT_TO', None)
+
+        if redirect_to is None:
+            raise Exception(
+                'Environment variable REDIRECT_TO not set. Use the deploy '
+                'script for proper configuration.'
+            )
+
         self.redirect(
-            "https://neptune.perts.net/participate/portal{}".format(
-                self.request.path_qs
+            "https://{redirect_to}{path_with_query_string}".format(
+                redirect_to=redirect_to,
+                path_with_query_string=self.request.path_qs,
             ),
             code=301,
         )

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "PERTS participation portal redirector",
   "version": "0.0.1",
   "engines": {
-    "node": "10"
+    "node": "16"
   },
   "license": "UNLICENSED",
   "repository": {
@@ -11,8 +11,9 @@
     "url": "git://github.com/PERTS/perts_me.git"
   },
   "scripts": {
+    "deploy": "./deploy.sh",
     "server": "dev_appserver.py . -A=perts-me --port=8001 --admin_port=8002 --storage_path=.gae_sdk --enable_console=yes --enable_host_checking=no --support_datastore_emulator=true",
-    "start": "npm run server"
+    "start": "if [ ! -f \"app.yaml\" ]; then echo \"Can't start app: app.yaml is missing. Run build_app_yaml.sh first\"; else npm run server; fi"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
## Background

Other collaborators have taken over the job of administering one of our apps, equitablelearning.org aka the "BELE Library". They asked for a rush redirection of equitablelearning.org to library.belenetwork.org, which they own. I did this with GoDaddy's domain forwarding service.

However, that does not redirect https URLS. Only http://equitablelearning.org was redirecting.

## Implementation

This implements a "server redirect" instead of something purely at the DNS layer so that the client and server can have a valid TLS handshake before the 301 is issued. I did this by re-using the code we already maintain which does this at perts.me.

I made the code more generic and added some scripts so you can easily deploy it to any project for any destination. It's working right now at (note the https) https://equitablelearning.org

If this is approved, I'll likely rename this repo so it's something like "redirector" instead of "perts_me".

Details on how to run and/or develop this are in the readme.